### PR TITLE
Fix #5 no longer activate accounts after token expiration

### DIFF
--- a/example/ndb_users/templates/activate-error.html
+++ b/example/ndb_users/templates/activate-error.html
@@ -37,18 +37,21 @@
 
 				<div class="form-login-item form-body">
 					
-					{% if not user %}
-					<p class="text-center">Your account could not be activated at this time. Please check the link and try again.</p>
-
+					{% if token_expired %}
+					<p class="text-center">Activation token has expired.</p>
+					<p class="text-center">Please <a href="{{ login_uri }}">log in</a> and request another activation email.</p>
 					{% else %}
-						{% if user.verified %}
-						<p class="text-center">Your account has already been activated.</p>
+						{% if not user %}
+						<p class="text-center">Your account could not be activated at this time. Please check the link and try again.</p>
 						{% else %}
-						<p class="text-center">Your account could not be activated at this time.</p>
-						{% endif %}
-
-						{% if continue_uri %}
-						<a class="btn btn-default btn-block" href="{{ continue_uri }}">Continue</a>
+							{% if user.verified %}
+							<p class="text-center">Your account has already been activated.</p>
+							{% else %}
+							<p class="text-center">Your account could not be activated at this time.</p>
+							{% endif %}
+							{% if continue_uri %}
+							<a class="btn btn-default btn-block" href="{{ continue_uri }}">Continue</a>
+							{% endif %}
 						{% endif %}
 					{% endif %}
 

--- a/example/ndb_users/templates/login-not-verified.html
+++ b/example/ndb_users/templates/login-not-verified.html
@@ -37,10 +37,10 @@
 
 				<div class="form-login-item form-body">
 					
-					<p class="text-center">Your email address has not been verified.</p>
-					
-					<p class="text-center">Please check your inbox for an account activation email.</p>
+					<p class="text-center text-muted"><em>We've just sent you another activation email!</em></p>
 
+					<p class="text-center">Your account will remain inactive until your email has been verified.</p>
+					
 				</div>
 				
 				<div class="form-login-item form-footer">

--- a/src/ndb_users/login.py
+++ b/src/ndb_users/login.py
@@ -47,6 +47,8 @@ from ndb_users.config import *
 
 from urllib import urlencode
 
+from datetime import datetime
+
 
 def _login_user_for_id(user_id):
   """ Logs in `user_id` bu creating a UserSession and setting the cookies.
@@ -147,12 +149,12 @@ class LoginPage(webapp2.RequestHandler):
               ))
             return None
           else:
-            # User not verified
+            # User email not verified (send another email)
+            _create_activation_email_for_user_id(user.key.string_id())
             self.response.out.write(template.render(
                 'ndb_users/templates/login-not-verified.html',
                 users.template_values()
               ))
-            return None
     # Error
     self.response.out.write(template.render(
         'ndb_users/templates/login-error.html',
@@ -341,23 +343,27 @@ class LoginActivate(webapp2.RequestHandler):
     """ Activate a user's account with for a given activation token. """
     activation_token = self.request.GET.get('token')
     user = users.get_current_user()
+    temp_values = {}
     if activation_token and not user:
       user_activation = ndb.Key(users.UserActivation, activation_token).get()
       if user_activation:
-        user = user_activation.activate_user()
-        if user:
-          _login_user_for_id(user.key.string_id())
-          self.response.out.write(template.render(
-              'ndb_users/templates/activate-success.html',
-              users.template_values()
-            ))
-        return None
+        if user_activation.expires > datetime.now():
+          user = user_activation.activate_user()
+          if user:
+            _login_user_for_id(user.key.string_id())
+            self.response.out.write(template.render(
+                'ndb_users/templates/activate-success.html',
+                users.template_values()
+              ))
+          return None
+        else:
+          temp_values['token_expired'] = True
     continue_uri = self.request.GET.get('continue')
     if user and continue_uri:
       self.redirect(continue_uri.encode('ascii'))
     self.response.out.write(template.render(
         'ndb_users/templates/activate-error.html',
-        users.template_values()
+        users.template_values(template_values=temp_values)
       ))
 
 

--- a/src/ndb_users/templates/activate-error.html
+++ b/src/ndb_users/templates/activate-error.html
@@ -37,18 +37,21 @@
 
 				<div class="form-login-item form-body">
 					
-					{% if not user %}
-					<p class="text-center">Your account could not be activated at this time. Please check the link and try again.</p>
-
+					{% if token_expired %}
+					<p class="text-center">Activation token has expired.</p>
+					<p class="text-center">Please <a href="{{ login_uri }}">log in</a> and request another activation email.</p>
 					{% else %}
-						{% if user.verified %}
-						<p class="text-center">Your account has already been activated.</p>
+						{% if not user %}
+						<p class="text-center">Your account could not be activated at this time. Please check the link and try again.</p>
 						{% else %}
-						<p class="text-center">Your account could not be activated at this time.</p>
-						{% endif %}
-
-						{% if continue_uri %}
-						<a class="btn btn-default btn-block" href="{{ continue_uri }}">Continue</a>
+							{% if user.verified %}
+							<p class="text-center">Your account has already been activated.</p>
+							{% else %}
+							<p class="text-center">Your account could not be activated at this time.</p>
+							{% endif %}
+							{% if continue_uri %}
+							<a class="btn btn-default btn-block" href="{{ continue_uri }}">Continue</a>
+							{% endif %}
 						{% endif %}
 					{% endif %}
 

--- a/src/ndb_users/templates/login-not-verified.html
+++ b/src/ndb_users/templates/login-not-verified.html
@@ -37,10 +37,10 @@
 
 				<div class="form-login-item form-body">
 					
-					<p class="text-center">Your email address has not been verified.</p>
-					
-					<p class="text-center">Please check your inbox for an account activation email.</p>
+					<p class="text-center text-muted"><em>We've just sent you another activation email!</em></p>
 
+					<p class="text-center">Your account will remain inactive until your email has been verified.</p>
+					
 				</div>
 				
 				<div class="form-login-item form-footer">


### PR DESCRIPTION
NDB_USERS_ACTIVATION_DAYS now works! In `LoginActivate` request handler, we now check that the `UserActivation.expires` value comes after today (now).
