### PR TITLE
Removed User.active

### DIFF
--- a/example/ndb_users/users.py
+++ b/example/ndb_users/users.py
@@ -219,7 +219,6 @@ class User(ndb.Model):
   email = ndb.StringProperty(required=True)
   passwordHash = ndb.StringProperty(required=True)
   passwordSalt = ndb.StringProperty(required=True)
-  active = ndb.BooleanProperty(default=False)
   verified = ndb.BooleanProperty(default=False)
   created = ndb.DateTimeProperty(auto_now_add=True)
   updated = ndb.DateTimeProperty(auto_now=True)

--- a/src/ndb_users/users.py
+++ b/src/ndb_users/users.py
@@ -219,7 +219,6 @@ class User(ndb.Model):
   email = ndb.StringProperty(required=True)
   passwordHash = ndb.StringProperty(required=True)
   passwordSalt = ndb.StringProperty(required=True)
-  active = ndb.BooleanProperty(default=False)
   verified = ndb.BooleanProperty(default=False)
   created = ndb.DateTimeProperty(auto_now_add=True)
   updated = ndb.DateTimeProperty(auto_now=True)


### PR DESCRIPTION
`User.active` property was never used. Removed because it was unnecessary. Closes #17
