### PR TITLE
_login links fixed when no redirect

### DIFF
--- a/example/ndb_users/login.py
+++ b/example/ndb_users/login.py
@@ -192,7 +192,7 @@ class LoginPage(webapp2.RequestHandler):
               'ndb_users/templates/login-success.html',
               users.template_values(template_values={
                   'user': user
-                })
+                }, user=user)
             ))
             return None
           else:

--- a/example/ndb_users/users.py
+++ b/example/ndb_users/users.py
@@ -136,7 +136,7 @@ def _append_query(base, query):
     return ''.join([base, '?', query])
   return base
 
-def template_values(template_values=dict(), query_options=dict()):
+def template_values(template_values=dict(), query_options=dict(), user=None):
   """ Return `template_values` plus the default key-value pairs. """
   request = webapp2.get_request()
   continue_uri = request.GET.get('continue')
@@ -145,7 +145,9 @@ def template_values(template_values=dict(), query_options=dict()):
     template_values.update(continue_uri=continue_uri)
   logout_query_options = query_options.copy()
   logout_query_options['action'] = 'logout'
-  user = get_current_user()
+  if not user:
+    # Only fetch via get_current_user() if `user` kwarg is None
+    user = get_current_user()
   if user:
     # Default key-value pairs with logged in user
     template_values.update(user={ 'email': user.email },

--- a/src/ndb_users/login.py
+++ b/src/ndb_users/login.py
@@ -192,7 +192,7 @@ class LoginPage(webapp2.RequestHandler):
               'ndb_users/templates/login-success.html',
               users.template_values(template_values={
                   'user': user
-                })
+                }, user=user)
             ))
             return None
           else:

--- a/src/ndb_users/users.py
+++ b/src/ndb_users/users.py
@@ -136,7 +136,7 @@ def _append_query(base, query):
     return ''.join([base, '?', query])
   return base
 
-def template_values(template_values=dict(), query_options=dict()):
+def template_values(template_values=dict(), query_options=dict(), user=None):
   """ Return `template_values` plus the default key-value pairs. """
   request = webapp2.get_request()
   continue_uri = request.GET.get('continue')
@@ -145,7 +145,9 @@ def template_values(template_values=dict(), query_options=dict()):
     template_values.update(continue_uri=continue_uri)
   logout_query_options = query_options.copy()
   logout_query_options['action'] = 'logout'
-  user = get_current_user()
+  if not user:
+    # Only fetch via get_current_user() if `user` kwarg is None
+    user = get_current_user()
   if user:
     # Default key-value pairs with logged in user
     template_values.update(user={ 'email': user.email },


### PR DESCRIPTION
`users.template_values()` relied upon `get_current_user()`, which used a request cookie. Because no request cookie is present during a login `get_current_user()` returned no user!

The fix: optional kwarg `user` has been added to `users.template_values()`, if this is specified and not `None`: the object passed as `user` will be used in lieu of `users.get_current_user()` (as `get_current_user()` looks for the request cookie, which isn't supplied in a login request!).
